### PR TITLE
[Feat] #32 Home API 연결 및 바인딩

### DIFF
--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/BaseRequest.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/BaseRequest.swift
@@ -10,24 +10,18 @@ import Alamofire
 import RxSwift
 
 final class BaseRequest {
-    static func request<T: Decodable>(_ endPoint: BaseEndpoint) -> Observable<Result<T, MDError>> {
+    static func request<T: Decodable>(_ endPoint: BaseEndpoint) -> Observable<T> {
         return Observable.create { observer in
             let request = APIManager.session.request(endPoint)
                 .responseDecodable { (response: AFDataResponse<T>) in
                     switch response.result {
                     case .success(let result):
-                        do {
-                            guard let statusCode = response.response?.statusCode else { return }
-                            try NetworkManager.statusCodeErrorHandling(statusCode)
-                            observer.onNext(.success(result))
+                            observer.onNext(result)
                             observer.onCompleted()
-                        } catch {
-                            guard let error = error as? MDError else { return }
-                            observer.onNext(.failure(error))
-                            observer.onCompleted()
-                        }
                     case .failure(_):
-                        observer.onError(MDError.serverError)
+                        guard let statusCode = response.response?.statusCode else { return }
+                        let error = NetworkManager.statusCodeErrorHandling(statusCode)
+                        observer.onError(error)
                     }
                 }
             return Disposables.create { request.cancel() }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/MDError.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/MDError.swift
@@ -12,6 +12,7 @@ enum MDError: Error {
     case tokenError
     case clientError
     case serverError
+    case castingError
     
     var text: String {
         switch self {
@@ -21,6 +22,8 @@ enum MDError: Error {
             return "시스템 오류입니다. 다시 요청해 주세요."
         case .serverError:
             return "네트워크 오류입니다. 다시 요청해 주세요"
+        case .castingError:
+            return "타입 캐스팅 실패"
         }
     }
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/NetworkManager.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/NetworkManager.swift
@@ -8,16 +8,24 @@
 import Foundation
 
 final class NetworkManager {
-    static func statusCodeErrorHandling(_ statusCode: Int) throws {
+    static func statusCodeErrorHandling(_ statusCode: Int) -> MDError {
         switch statusCode {
         case 204:
-            throw MDError.tokenError
+            return MDError.tokenError
         case 400..<500:
-            throw MDError.clientError
+            return MDError.clientError
         case 500...:
-            throw MDError.serverError
+            return MDError.serverError
         default:
-            return
+            return MDError.serverError
+        }
+    }
+    
+    static func handleError(_ error: Error) -> MDError {
+        if let mdError = error as? MDError {
+            return mdError
+        } else {
+            return MDError.castingError
         }
     }
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/HomeService.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/HomeService.swift
@@ -10,7 +10,7 @@ import Alamofire
 import RxSwift
 
 final class HomeService {
-    static func getHomeAPI() -> Single<HomeResponse> {
+    static func getHomeAPI() -> Observable<Result<HomeResponse, MDError>> {
         return BaseRequest.request(HomeEndPoint.getHomeAPI)
     }
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/HomeService.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/HomeService.swift
@@ -10,7 +10,7 @@ import Alamofire
 import RxSwift
 
 final class HomeService {
-    static func getHomeAPI() -> Observable<Result<HomeResponse, MDError>> {
+    static func getHomeAPI() -> Observable<HomeResponse> {
         return BaseRequest.request(HomeEndPoint.getHomeAPI)
     }
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Model/MapDeviceInset.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Model/MapDeviceInset.swift
@@ -56,7 +56,7 @@ enum MapDeviceInset {
         }
     }
     
-    func deviceInset(size: DeviceSize) -> TopAndLeadingInset {
+    static func deviceInset(size: DeviceSize) -> TopAndLeadingInset {
         switch (size.width, size.height) {
         case (430, 932):
             return MapDeviceInset.width430Height932.inset

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Model/OpacityColorType.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Model/OpacityColorType.swift
@@ -15,6 +15,25 @@ enum OpacityColorType: Codable {
     case blue(Int)
     case purple(Int)
     
+    init(_ colorString: String, _ opacity: Int) {
+        switch colorString.lowercased() {
+        case "pink":
+            self = .pink(opacity)
+        case "orange":
+            self = .orange(opacity)
+        case "yellow":
+            self = .yellow(opacity)
+        case "green":
+            self = .green(opacity)
+        case "blue":
+            self = .blue(opacity)
+        case "purple":
+            self = .purple(opacity)
+        default:
+            self = .pink(0)
+        }
+    }
+    
     var color: UIColor {
         switch self {
         case .pink(let opacity):
@@ -38,7 +57,7 @@ enum OpacityColorType: Codable {
             return .mapPink1
         case 2:
             return .mapPink2
-        case 3:
+        case 3...:
             return .mapPink3
         default:
             return .mapGray
@@ -51,7 +70,7 @@ enum OpacityColorType: Codable {
             return .mapOrange1
         case 2:
             return .mapOrange2
-        case 3:
+        case 3...:
             return .mapOrange3
         default:
             return .mapGray
@@ -64,7 +83,7 @@ enum OpacityColorType: Codable {
             return .mapYellow1
         case 2:
             return .mapYellow2
-        case 3:
+        case 3...:
             return .mapYellow3
         default:
             return .mapGray
@@ -77,7 +96,7 @@ enum OpacityColorType: Codable {
             return .mapGreen1
         case 2:
             return .mapGreen2
-        case 3:
+        case 3...:
             return .mapGreen3
         default:
             return .mapGray
@@ -90,7 +109,7 @@ enum OpacityColorType: Codable {
             return .mapBlue1
         case 2:
             return .mapBlue2
-        case 3:
+        case 3...:
             return .mapBlue3
         default:
             return .mapGray
@@ -103,7 +122,7 @@ enum OpacityColorType: Codable {
             return .mapPurple1
         case 2:
             return .mapPurple2
-        case 3:
+        case 3...:
             return .mapPurple3
         default:
             return .mapGray

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Reactor/HomeMapReactor.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Reactor/HomeMapReactor.swift
@@ -38,14 +38,14 @@ final class HomeMapReactor: Reactor {
         switch action {
         case .viewWillAppear:
             return HomeService.getHomeAPI()
-                .flatMap { result -> Observable<Mutation> in
-                    switch result {
-                    case .success(let response):
-                        return Observable.just(Mutation.setTotalMap(self.prepareTotalMap(response)))
-                    case .failure(let error):
-                        print("Error occurred: \(error)")
-                        return Observable.just(Mutation.setError(error)) // 에러 처리용 Mutation
-                    }
+                .map { response in
+                    // 성공적인 경우
+                    return Mutation.setTotalMap(self.prepareTotalMap(response))
+                }
+                .catch { error in
+                    // 에러 발생 시
+//                    NetworkManager.handleError(error)
+                    return Observable.just(Mutation.setError(NetworkManager.handleError(error)))
                 }
         case .mapAction(let type):
             return Observable.just(Mutation.setSelectedMap(prepareSelectedMap(type: type)))

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Reactor/HomeMapReactor.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/Reactor/HomeMapReactor.swift
@@ -39,12 +39,9 @@ final class HomeMapReactor: Reactor {
         case .viewWillAppear:
             return HomeService.getHomeAPI()
                 .map { response in
-                    // 성공적인 경우
                     return Mutation.setTotalMap(self.prepareTotalMap(response))
                 }
                 .catch { error in
-                    // 에러 발생 시
-//                    NetworkManager.handleError(error)
                     return Observable.just(Mutation.setError(NetworkManager.handleError(error)))
                 }
         case .mapAction(let type):
@@ -58,7 +55,6 @@ final class HomeMapReactor: Reactor {
         var newState = state
         switch mutation {
         case .setTotalMap(let model):
-            print("⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️", model)
             newState.totalMapState = model
         case .setSelectedMap(let specificModel):
             newState.totalMapState?.selectedMap = specificModel

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/ViewController/HomeMapViewController.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Home/ViewController/HomeMapViewController.swift
@@ -126,7 +126,7 @@ final class HomeMapViewController: UIViewController, View {
             }
             .disposed(by: disposeBag)
         
-        reactor.state.map{ $0.totalMapState }
+        reactor.state.compactMap { $0.totalMapState }
             .withUnretained(self)
             .subscribe { _, data in
                 for model in data.totalMapArray {
@@ -180,7 +180,7 @@ final class HomeMapViewController: UIViewController, View {
             .disposed(by: disposeBag)
         
         recordButton.rx.tap
-            .compactMap { reactor.initialState.selectedMap }
+            .compactMap { reactor.initialState.totalMapState?.selectedMap?.selectedMapName }
             .asDriver(onErrorJustReturn: "서울")
             .drive(with: self) { owner, text in
                 let recordVC = RecordViewController(reactor: RecordReactor(),


### PR DESCRIPTION
##  작업한 내용
- Home API 연결하고 바인딩까지 진행했습니다.
- 더미로 가지고 있던 지도 데이터, 전역으로 여러 곳에서 영향을 주고 있던 데이터들 전부 제거했습니다. 데이터 흐름이 깔끔해졌어요.
- BaseRequest 구조를 변경하고, 이제 Result 타입으로 값을 받지 않아서 ReactorKit에서 Error 타입을 MDError로 따로 캐스팅 해 주어야 하기 때문에 handleError 메서드도 추가했습니다. 5f00ff7fa5f624f31c02de4f8b9f18293a572b32
- 코드 확인해 주시고 이해 안 되는 부분 리뷰 남겨 주세요.

## 스크린샷

|뷰|설명|
|------|---|
|![스크린샷 2024-09-21 오후 10 22 43](https://github.com/user-attachments/assets/9fffa762-c692-4d21-82bc-912a2bd272da) |   경기도, 서울, 강원도, 제주도에 방문 기록이 있는 모습! |

## 관련 이슈

- Resolved: #32 
