### PR TITLE
[Feat] #38 - 애플 재로그인 이슈 해결

### DIFF
--- a/dnd-11th-4-iOS/dnd-11th-4-iOS.xcodeproj/project.pbxproj
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS.xcodeproj/project.pbxproj
@@ -1284,7 +1284,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = D5WYU8R9W8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "dnd-11th-4-iOS/Application/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "맵땅-DEV";
+				INFOPLIST_KEY_CFBundleDisplayName = "맵땅";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "맵땅에 사진을 추가하려면 사진 라이브러리 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSUserTrackingUsageDescription = "\"맵땅 앱에서 사용자에게 최적화된 광고를 제공하기 위해 정보를 수집하려 합니다.\"";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1298,7 +1298,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.record.mapddang-dev";
+				PRODUCT_BUNDLE_IDENTIFIER = com.record.mapddang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "MapDDang Debug";

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/BaseRequest.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/BaseRequest.swift
@@ -10,10 +10,11 @@ import Alamofire
 import RxSwift
 
 final class BaseRequest {
+    
     static func request<T: Decodable>(_ endPoint: BaseEndpoint) -> Observable<T> {
         return Observable.create { observer in
             let request = APIManager.session.request(endPoint)
-                .responseDecodable { (response: AFDataResponse<T>) in
+                .responseDecodable(of: T.self, emptyResponseCodes: [200]) { (response: AFDataResponse) in
                     switch response.result {
                     case .success(let result):
                             observer.onNext(result)

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/TokenManager.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Base/TokenManager.swift
@@ -11,6 +11,7 @@ final class TokenManager {
     private enum Keys {
         static let accessToken = "accessToken"
         static let refreshToken = "refreshToken"
+        static let appleRefreshToken = "appleRefreshToken"
     }
     
     static let shared = TokenManager()
@@ -32,6 +33,13 @@ final class TokenManager {
         UserDefaults.standard.set(refreshToken, forKey: Keys.refreshToken)
         temporaryToken = nil
     }
+    
+    func saveTokensWithAppleRefreshToken(accessToken: String, refreshToken: String, appleRefreshToken: String) {
+        UserDefaults.standard.set(accessToken, forKey: Keys.accessToken)
+        UserDefaults.standard.set(refreshToken, forKey: Keys.refreshToken)
+        UserDefaults.standard.set(appleRefreshToken, forKey: Keys.appleRefreshToken)
+        temporaryToken = nil
+    }
 
     func getAccessToken() -> String? {
         return UserDefaults.standard.string(forKey: Keys.accessToken)
@@ -40,9 +48,14 @@ final class TokenManager {
     func getRefreshToken() -> String? {
         return UserDefaults.standard.string(forKey: Keys.refreshToken)
     }
+    
+    func getAppleRefreshToken() -> String? {
+        return UserDefaults.standard.string(forKey: Keys.appleRefreshToken)
+    }
 
     func clearTokens() {
         UserDefaults.standard.removeObject(forKey: Keys.accessToken)
         UserDefaults.standard.removeObject(forKey: Keys.refreshToken)
+        UserDefaults.standard.removeObject(forKey: Keys.appleRefreshToken)
     }
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/EndPoint/LoginEndPoint.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/EndPoint/LoginEndPoint.swift
@@ -56,9 +56,20 @@ extension LoginEndPoint: BaseEndpoint {
     }
     
     var headers: HTTPHeaders? {
-        return [
-            "Content-Type": "application/json",
-            "accept": "application/json"
-        ]
+        switch self {
+        case .appleLoginAPI, .reIssueTokenAPI:
+            return [
+                "Content-Type": "application/json",
+                "accept": "application/json"
+            ]
+        case .withdrawAPI:
+            guard let token = TokenManager.shared.getAccessToken() else {
+                return .none
+            }
+            return [
+            "accept": "application/json",
+            "Authorization": "Bearer \(token)"
+            ]
+        }
     }
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginRequest.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginRequest.swift
@@ -17,5 +17,6 @@ struct RefreshTokenRequest: Encodable {
 }
 
 struct WithdrawRequest: Encodable {
-    let authorizationCode: String
+    //TODO: appleRefreshToken으로 변경
+    let refreshToken: String
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginRequest.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct LoginRequest: Encodable {
-    let appleToken: String
+    let authorizationCode: String
     let selectedColor: String
 }
 

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginRequest.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginRequest.swift
@@ -17,6 +17,5 @@ struct RefreshTokenRequest: Encodable {
 }
 
 struct WithdrawRequest: Encodable {
-    //TODO: appleRefreshToken으로 변경
-    let refreshToken: String
+    let appleRefreshToken: String
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginResponse.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginResponse.swift
@@ -10,4 +10,5 @@ import Foundation
 struct LoginResponse: Decodable {
     let accessToken: String
     let refreshToken: String
+    let appleRefreshToken: String
 }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginResponse.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Model/Login/LoginResponse.swift
@@ -12,3 +12,8 @@ struct LoginResponse: Decodable {
     let refreshToken: String
     let appleRefreshToken: String
 }
+
+struct reissueResponse: Decodable {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/LoginService.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/LoginService.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 final class LoginService {
     static func appleLogin(token: String, color: String) -> Observable<LoginResponse> {
-        let request = LoginRequest(appleToken: token, selectedColor: color)
+        let request = LoginRequest(authorizationCode: token, selectedColor: color)
         return BaseRequest.request(LoginEndPoint.appleLoginAPI(request))
     }
     

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/LoginService.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Network/Service/LoginService.swift
@@ -15,7 +15,7 @@ final class LoginService {
         return BaseRequest.request(LoginEndPoint.appleLoginAPI(request))
     }
     
-    static func reIssueToken(request: RefreshTokenRequest) -> Observable<LoginResponse> {
+    static func reIssueToken(request: RefreshTokenRequest) -> Observable<reissueResponse> {
         return BaseRequest.request(LoginEndPoint.reIssueTokenAPI(request))
     }
     

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/MyPage/Reactor/AccountDeleteReactor.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/MyPage/Reactor/AccountDeleteReactor.swift
@@ -35,10 +35,10 @@ extension AccountDeleteReactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .deleteAccount:
-            guard let refreshToken = TokenManager.shared.getRefreshToken() else {
+            guard let appleRefreshToken = TokenManager.shared.getAppleRefreshToken() else {
                 return Observable.just(Mutation.setError(MDError.tokenError))
             }
-            let request = WithdrawRequest(authorizationCode: refreshToken)
+            let request = WithdrawRequest(refreshToken: appleRefreshToken)
             return LoginService.revokeToken(request: request)
                 .flatMap { _ -> Observable<Mutation> in
                     TokenManager.shared.clearTokens()

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/MyPage/Reactor/AccountDeleteReactor.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/MyPage/Reactor/AccountDeleteReactor.swift
@@ -38,7 +38,7 @@ extension AccountDeleteReactor {
             guard let appleRefreshToken = TokenManager.shared.getAppleRefreshToken() else {
                 return Observable.just(Mutation.setError(MDError.tokenError))
             }
-            let request = WithdrawRequest(refreshToken: appleRefreshToken)
+            let request = WithdrawRequest(appleRefreshToken: appleRefreshToken)
             return LoginService.revokeToken(request: request)
                 .flatMap { _ -> Observable<Mutation> in
                     TokenManager.shared.clearTokens()

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -33,10 +33,15 @@ final class MyPageViewController: UIViewController {
         bindActions()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        reactor?.action.onNext(.fetchUserName)
+    }
+    
     init(reactor: MyPageReactor) {
         super.init(nibName: nil, bundle: nil)
         self.reactor = reactor
-        reactor.action.onNext(.fetchUserName)
+//        reactor.action.onNext(.fetchUserName)
     }
     
     required init?(coder: NSCoder) {

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Onboarding/Reactor/OnboardingReactor.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/Onboarding/Reactor/OnboardingReactor.swift
@@ -20,7 +20,7 @@ final class OnboardingReactor: Reactor {
     enum Mutation {
         case setAnimation(String)
         case setSelectedColor(ColorType)
-        case setLoginSuccess(accessToken: String, refreshToken: String)
+        case setLoginSuccess(accessToken: String, refreshToken: String, appleRefreshToken: String)
         case setError(MDError)
     }
     
@@ -52,7 +52,9 @@ extension OnboardingReactor {
             
             let apiRequest = LoginService.appleLogin(token: token, color: color.serverName)
                 .map { response in
-                    return Mutation.setLoginSuccess(accessToken: response.accessToken, refreshToken: response.refreshToken)
+                    return Mutation.setLoginSuccess(accessToken: response.accessToken,
+                                                    refreshToken: response.refreshToken,
+                                                    appleRefreshToken: response.appleRefreshToken)
                 }
                 .catch { error in
                     let handledError = NetworkManager.handleError(error)
@@ -70,9 +72,11 @@ extension OnboardingReactor {
             newState.selectedAnimation = animationName
         case .setSelectedColor(let color):
             newState.selectedColor = color
-        case .setLoginSuccess(let accessToken, let refreshToken):
+        case .setLoginSuccess(let accessToken, let refreshToken, let appleToken):
             newState.isLoginSuccess = true
-            TokenManager.shared.saveTokens(accessToken: accessToken, refreshToken: refreshToken)
+            TokenManager.shared.saveTokensWithAppleRefreshToken(accessToken: accessToken,
+                                                         refreshToken: refreshToken,
+                                                         appleRefreshToken: appleToken)
         case .setError(let error):
             newState.error = error
         }

--- a/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/RecordList/ViewController/RecordListViewController.swift
+++ b/dnd-11th-4-iOS/dnd-11th-4-iOS/Presentation/RecordList/ViewController/RecordListViewController.swift
@@ -44,10 +44,14 @@ final class RecordListViewController: UIViewController {
         self.tabBarController?.tabBar.isHidden = false
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        reactor?.action.onNext(.loadRecords)
+    }
+    
     init(reactor: RecordListReactor) {
         super.init(nibName: nil, bundle: nil)
         self.reactor = reactor
-        reactor.action.onNext(.loadRecords)
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
##  작업한 내용
- 애플 재로그인 실패하는 이슈 해결했습니다.
- 맵땅 로그인 API 호출 성공시, access, refresh, appleRefresh 총 세 개의 값을 받도록 변경되었고 그에 따른 response도 함께 수정해 두었습니다.

```swift
struct LoginResponse: Decodable {
    let accessToken: String
    let refreshToken: String
    let appleRefreshToken: String
}
```

- TokenManager에 apple refreshToken을 추가하고 삭제하는 과정도 추가해 두었습니다.
- 로그인 성공 후, Tabbar로 진입할 때 Tabbar에 등록되어 있는 모든 VC의 API들이 호출되는 이슈가 있었습니다. viewDidAppear 메서드에 API 호출 코드를 옮겨서 실제 다른 탭뷰에 진입했을 때, API가 요청되도록 수정해서 해결해 놓았습니다.

```swift
    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)
        reactor?.action.onNext(.loadRecords)
    }
```

## 관련 이슈

- Resolved: #38 
